### PR TITLE
Fix a typo on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1137,7 +1137,7 @@
               </dt>
               <dd class="mt-2 md:mt-0 md:col-span-7">
                 <p class="text-base leading-6 text-gray-500">
-                  I'm an independent developer myself, and I don't have the ability to spend years on my own product only to have Apple change the rules on me mid-stream. I have a vested interest in Apple changing it's practices here.
+                  I'm an independent developer myself, and I don't have the ability to spend years on my own product only to have Apple change the rules on me mid-stream. I have a vested interest in Apple changing its practices here.
                 </p>
               </dd>
             </div>


### PR DESCRIPTION
Teeny tiny typo on home page (it's => its).